### PR TITLE
Fix divide by zero bug

### DIFF
--- a/tonic_validate/metrics/augmentation_accuracy_metric.py
+++ b/tonic_validate/metrics/augmentation_accuracy_metric.py
@@ -19,6 +19,12 @@ class AugmentationAccuracyMetric(Metric):
         self, llm_response: LLMResponse, openai_service: OpenAIService
     ) -> Tuple[float, List[bool]]:
         contains_context_list = []
+        if len(llm_response.llm_context_list) == 0:
+            logger.warning(
+                "No context provided for augmentation accuracy metric, "
+                "setting score to 0.0"
+            )
+            return (0.0, [])
         for context in llm_response.llm_context_list:
             contains_context_response = answer_contains_context_call(
                 llm_response.llm_answer, context, openai_service

--- a/tonic_validate/metrics/retrieval_precision_metric.py
+++ b/tonic_validate/metrics/retrieval_precision_metric.py
@@ -18,6 +18,12 @@ class RetrievalPrecisionMetric(Metric):
     def calculate_metric(
         self, llm_response: LLMResponse, openai_service: OpenAIService
     ) -> Tuple[float, List[bool]]:
+        if len(llm_response.llm_context_list) == 0:
+            logger.warning(
+                "No context provided for retrieval precision metric, "
+                "setting score to 0.0"
+            )
+            return (0.0, [])
         context_relevant_list = []
         for context in llm_response.llm_context_list:
             relevance_response = context_relevancy_call(


### PR DESCRIPTION
For retrieval precision and augmentation precision scores, if no context is passed to the scorer then we would get a divide by zero error. This PR makes it so that in this case a warning is logged that the metric was attempted to be scored with no context and a score of 0.0 is returned.