### PR TITLE
Return run id

### DIFF
--- a/tonic_validate/validate_api.py
+++ b/tonic_validate/validate_api.py
@@ -31,7 +31,7 @@ class ValidateApi:
                 raise Exception(exception_message)
         self.client = HttpClient(base_url, api_key)
 
-    def upload_run(self, project_id: str, run: Run) -> None:
+    def upload_run(self, project_id: str, run: Run) -> str:
         """Upload a run to a Tonic Validate project.
 
         Parameters
@@ -47,6 +47,7 @@ class ValidateApi:
                 f"/projects/{project_id}/runs/{run_response['id']}/logs",
                 data=run_data.to_dict(),
             )
+        return run_response["id"]
 
     def get_benchmark(self, benchmark_id: str) -> Benchmark:
         """Get a Tonic Validate benchmark by its ID.


### PR DESCRIPTION
When uploading a run to the Tonic Validate UI, return the recorded run id, instead of returning None. This allows the user to know which runs in their Python environment are associated with which runs in the Tonic Validate UI.