### PR TITLE
Handle metric scoring exceptions better

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,12 @@ scorer = ValidateScorer([
 ], model_evaluator="gpt-3.5-turbo")
 ```
 
+If an error occurs while scoring an item's metric, the score for that metric will be set to `None`. If you instead wish to have Tonic Validate throw an exception when there's an error scoring, then set `fail_on_error` to `True` in the constructor
+
+```python
+scorer = ValidateScorer(fail_on_error=True)
+```
+
 ### **Important**: Using the scorer on Azure
 If you are using Azure, you MUST set the `model_evaluator` argument to your deployment name like so
 ```python

--- a/tonic_validate/classes/run.py
+++ b/tonic_validate/classes/run.py
@@ -1,17 +1,17 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Dict, Union
 from dataclasses import dataclass
 from uuid import UUID
 
 
 @dataclass
 class RunData:
-    scores: dict[str, float | None]
+    scores: Dict[str, Union[float, None]]
     reference_question: str
     reference_answer: Optional[str]
     llm_answer: str
     llm_context: Optional[List[str]]
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         return {
             "scores": self.scores,
             "reference_question": self.reference_question,
@@ -23,6 +23,6 @@ class RunData:
 
 @dataclass
 class Run:
-    overall_scores: dict[str, float]
+    overall_scores: Dict[str, float]
     run_data: List[RunData]
     id: Optional[UUID]

--- a/tonic_validate/classes/run.py
+++ b/tonic_validate/classes/run.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 @dataclass
 class RunData:
-    scores: dict[str, float]
+    scores: dict[str, float | None]
     reference_question: str
     reference_answer: Optional[str]
     llm_answer: str

--- a/tonic_validate/metrics/answer_similarity_metric.py
+++ b/tonic_validate/metrics/answer_similarity_metric.py
@@ -13,8 +13,7 @@ class AnswerSimilarityMetric(Metric):
     def score(self, llm_response: LLMResponse, openai_service: OpenAIService) -> float:
         # Check that the benchmark item has an answer
         if llm_response.benchmark_item.answer is None:
-            error_message = "The benchmark item does not have an answer"
-            raise ValueError(error_message)
+            raise ValueError("The benchmark item does not have an answer")
 
         similarity_score_response = similarity_score_call(
             llm_response.benchmark_item.question,
@@ -25,9 +24,8 @@ class AnswerSimilarityMetric(Metric):
         try:
             similarity_score = float(similarity_score_response)
         except ValueError:
-            error_message = (
+            raise ValueError(
                 f"Failed to parse similarity score {similarity_score_response} as float"
             )
-            raise ValueError(error_message)
 
         return similarity_score

--- a/tonic_validate/metrics/answer_similarity_metric.py
+++ b/tonic_validate/metrics/answer_similarity_metric.py
@@ -13,11 +13,8 @@ class AnswerSimilarityMetric(Metric):
     def score(self, llm_response: LLMResponse, openai_service: OpenAIService) -> float:
         # Check that the benchmark item has an answer
         if llm_response.benchmark_item.answer is None:
-            error_message = (
-                "Benchmark item has no answer, cannot calculate answer similarity"
-            )
-            logger.error(error_message)
-            return 0.0
+            error_message = "The benchmark item does not have an answer"
+            raise ValueError(error_message)
 
         similarity_score_response = similarity_score_call(
             llm_response.benchmark_item.question,

--- a/tonic_validate/metrics/answer_similarity_metric.py
+++ b/tonic_validate/metrics/answer_similarity_metric.py
@@ -29,10 +29,8 @@ class AnswerSimilarityMetric(Metric):
             similarity_score = float(similarity_score_response)
         except ValueError:
             error_message = (
-                f"Failed to parse similarity score {similarity_score_response} as "
-                "float, setting score to 0.0"
+                f"Failed to parse similarity score {similarity_score_response} as float"
             )
-            logger.error(error_message)
-            similarity_score = 0.0
+            raise ValueError(error_message)
 
         return similarity_score

--- a/tonic_validate/metrics/augmentation_accuracy_metric.py
+++ b/tonic_validate/metrics/augmentation_accuracy_metric.py
@@ -20,11 +20,9 @@ class AugmentationAccuracyMetric(Metric):
     ) -> Tuple[float, List[bool]]:
         contains_context_list: List[bool] = []
         if len(llm_response.llm_context_list) == 0:
-            logger.warning(
-                "No context provided for augmentation accuracy metric, "
-                "setting score to 0.0"
+            raise ValueError(
+                "No context provided, cannot calculate augmentation accuracy"
             )
-            return (0.0, [])
         for context in llm_response.llm_context_list:
             contains_context_response = answer_contains_context_call(
                 llm_response.llm_answer, context, openai_service

--- a/tonic_validate/metrics/retrieval_precision_metric.py
+++ b/tonic_validate/metrics/retrieval_precision_metric.py
@@ -19,11 +19,9 @@ class RetrievalPrecisionMetric(Metric):
         self, llm_response: LLMResponse, openai_service: OpenAIService
     ) -> Tuple[float, List[bool]]:
         if len(llm_response.llm_context_list) == 0:
-            logger.warning(
-                "No context provided for retrieval precision metric, "
-                "setting score to 0.0"
+            raise ValueError(
+                "No context provided, cannot calculate retrieval precision"
             )
-            return (0.0, [])
         context_relevant_list: List[bool] = []
         for context in llm_response.llm_context_list:
             relevance_response = context_relevancy_call(

--- a/tonic_validate/utils/http_client.py
+++ b/tonic_validate/utils/http_client.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 import requests
 from urllib3.exceptions import InsecureRequestWarning  # type: ignore
 
@@ -22,7 +22,7 @@ class HttpClient:
         self.base_url = base_url
         self.headers = {"Authorization": f"Bearer {access_token}"}
 
-    def http_get(self, url: str, params: dict[Any, Any] = {}) -> Any:
+    def http_get(self, url: str, params: Dict[Any, Any] = {}) -> Any:
         """Make a get request.
 
         Parameters
@@ -40,7 +40,7 @@ class HttpClient:
         return res.json()
 
     def http_post(
-        self, url: str, params: dict[Any, Any] = {}, data: dict[Any, Any] = {}
+        self, url: str, params: Dict[Any, Any] = {}, data: Dict[Any, Any] = {}
     ) -> Any:
         """Make a post request.
 
@@ -64,7 +64,7 @@ class HttpClient:
         return res.json()
 
     def http_put(
-        self, url: str, params: dict[Any, Any] = {}, data: dict[Any, Any] = {}
+        self, url: str, params: Dict[Any, Any] = {}, data: Dict[Any, Any] = {}
     ) -> Any:
         """Make a put request.
 

--- a/tonic_validate/utils/metrics_util.py
+++ b/tonic_validate/utils/metrics_util.py
@@ -29,12 +29,9 @@ def parse_boolean_response(response: str) -> bool:
         return True
     if "false" in response_lower and "true" not in response_lower:
         return False
-    log_message = (
+    raise ValueError(
         f"Could not determine true or false from response {response_lower}"
-        ", returning False"
     )
-    logger.debug(log_message)
-    return False
 
 
 def parse_bullet_list_response(response: str) -> List[str]:
@@ -54,13 +51,6 @@ def parse_bullet_list_response(response: str) -> List[str]:
     List[str]
         List of strings that correspond to the bullet points in the response.
     """
-    if "*" not in response:
-        log_message = (
-            f"Response {response} does not contain bullet list. Returning all of "
-            "response as main point."
-        )
-        logger.debug(log_message)
-        return [response]
     if not response.startswith("*"):
         log_message = (
             f"Response {response} does not start with bullet, when it should be a "
@@ -69,4 +59,6 @@ def parse_bullet_list_response(response: str) -> List[str]:
         logger.debug(log_message)
     bullet_list = response.split("*")[1:]
     bullet_list = [bullet.strip() for bullet in bullet_list]
+    if len(bullet_list) == 0:
+        raise ValueError(f"Could not parse bullet list from response {response}")
     return bullet_list

--- a/tonic_validate/validate_api.py
+++ b/tonic_validate/validate_api.py
@@ -46,7 +46,7 @@ class ValidateApi:
             Metadata to attach to the run. If the values are not strings, then they are
             converted to strings before making the request.
         """
-        # ensure run_metadata is dict[str, str]
+        # ensure run_metadata is Dict[str, str]
         processed_run_metadata = {
             str(key): str(value) for key, value in run_metadata.items()
         }

--- a/tonic_validate/validate_scorer.py
+++ b/tonic_validate/validate_scorer.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
-from typing import Callable, DefaultDict, List
+from typing import Callable, DefaultDict, List, Dict, Union
 from tonic_validate.classes.benchmark import Benchmark, BenchmarkItem
 import logging
 
@@ -52,7 +52,7 @@ class ValidateScorer:
             self.encoder = tiktoken.get_encoding("cl100k_base")
 
     def _score_item_rundata(self, response: LLMResponse) -> RunData:
-        scores: dict[str, float | None] = {}
+        scores: Dict[str, Union[float, None]] = {}
         # We cache per response, so we need to create a new OpenAIService
         openai_service = OpenAIService(self.encoder, self.model_evaluator)
         for metric in self.metrics:
@@ -61,7 +61,7 @@ class ValidateScorer:
             except Exception as e:
                 if not self.fail_on_error:
                     score = None
-                    logger.error(f"Error calculating score for {metric.name}")
+                    logger.error(f"Error calculating score for {metric.name}, setting score to None.")
                 else:
                     raise e
             scores[metric.name] = score
@@ -107,7 +107,7 @@ class ValidateScorer:
                     total_scores[metric_name] += score
                     num_scores[metric_name] += 1
 
-        overall_scores: dict[str, float] = {
+        overall_scores: Dict[str, float] = {
             metric: total / num_scores[metric] for metric, total in total_scores.items()
         }
 


### PR DESCRIPTION
Right now, Tonic Validate will just return `0` when a metric fails to be scored which throws off the accuracy of the metrics. This PR instead sets the metric to `None` and calculates the overall scores from the metrics that are not None. We also expose `fail_on_error` in the `ValidateScorer` constructor which when `True` will instead throw an exception when a metric fails to be scored instead of just returning `None`