### PR TITLE
Set up pypi readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <picture>
-  <source media="(prefers-color-scheme: light)" srcset="./readme_images/TonicValidate-Horizontal-Dark-Icon.svg">
-  <source media="(prefers-color-scheme: dark)" srcset="./readme_images/TonicValidate-Horizontal-White-Icon.svg">
-  <img src="./readme_images/TonicValidate-Horizontal-Dark-Icon.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/TonicAI/tonic_validate/main/readme_images/TonicValidate-Horizontal-Dark-Icon.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/TonicAI/tonic_validate/main/readme_images/TonicValidate-Horizontal-White-Icon.svg">
+  <img src="https://raw.githubusercontent.com/TonicAI/tonic_validate/main/readme_images/TonicValidate-Horizontal-Dark-Icon.svg">
 </picture>
 
 Tonic Validate is a platform for Retrieval Augmented Generation (RAG) development and experiment tracking. This repository, `tonic_validate` (formerly `tvalmetrics`) is the SDK component of Tonic Validate. It contains the code for calculating RAG metrics and optionally logging them to the [Tonic Validate UI](https://www.tonic.ai/validate).
@@ -11,7 +11,7 @@ Tonic Validate is a platform for Retrieval Augmented Generation (RAG) developmen
 ## Check Out Our UI to Visualize Your Results
 In addition to the SDK, we also have a **free to use UI**. While **using the UI isn't required to use the SDK**, it does allow you to easily visualize your results. To sign up, click [here](https://validate.tonic.ai/).  
 <picture>
-  <img src="./readme_images/TonicValidate-Graph.png" width="800">
+  <img src="https://raw.githubusercontent.com/TonicAI/tonic_validate/main/readme_images/TonicValidate-Graph.png" width="800">
 </picture>
 
 
@@ -354,7 +354,7 @@ You can easily view your run results by uploading them to our **free to use UI**
 Once you sign up for the UI, you will go through an onboarding to create an API Key and Project.
 
 <picture>
-  <img src="./readme_images/TonicValidate-Onboarding.png" width="800">
+  <img src="https://raw.githubusercontent.com/TonicAI/tonic_validate/main/readme_images/TonicValidate-Onboarding.png" width="800">
 </picture>
 
 Copy both the API Key and Project ID from the onboarding and insert it into the following code
@@ -365,12 +365,12 @@ validate_api.upload_run("your-project-id", run)
 ```
 This will upload your run to the Tonic Validate UI where you can view the results. On the home page (as seen below) you can view the change in scores across runs over time.  
 <picture>
-  <img src="./readme_images/TonicValidate-Graph.png" width="800">
+  <img src="https://raw.githubusercontent.com/TonicAI/tonic_validate/main/readme_images/TonicValidate-Graph.png" width="800">
 </picture>
 
 You can also view the results of an individual run in the UI as well.  
 <picture>
-  <img src="./readme_images/TonicValidate-Run.png" width="800">
+  <img src="https://raw.githubusercontent.com/TonicAI/tonic_validate/main/readme_images/TonicValidate-Run.png" width="800">
 </picture>
 
 # FAQ

--- a/pypi_readme.md
+++ b/pypi_readme.md
@@ -1,7 +1,0 @@
-# Tonic Validate
-
-Tonic Validate is for evaluating RAG applications. See our [github](https://github.com/TonicAI/tonic_validate) for more information.
-
-* **Github**: [https://github.com/TonicAI/tonic_validate](https://github.com/TonicAI/tonic_validate) 
-
-Sign up for a free Tonic Validate account at [validate.tonic.ai](https://validate.tonic.ai) to try it out.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "tonic-validate"
 version = "3.0.1"
 description = "RAG evaluation metrics."
 authors = ["Joe Ferrara <joeferrara@tonic.ai>", "Ethan Philpott <ephilpott@tonic.ai>"]
-readme = "pypi_readme.md"
+readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0.0"


### PR DESCRIPTION
This is a bit of a hack so we can reuse our readme for pypi. It changes the relative links to absolute links. In the future though, I'd like to have a github action that runs on merge to auto replace relative links with absolute links using regex.