### PR TITLE
Added telemetry linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ docs/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+.env

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Tonic Validate collects minimal telemetry to help us figure out what users want 
 
 We do **NOT** track things such as the contents of the questions / answers, your scores, or any other sensitive information.
 
-We also generate a random UUID to help us figure out how many users are using the product. This UUID is not linked to your Tonic Validate account if you are using the web interface. It is solely there to help us get user counts. If you want to see how we implemented telemetry, you can do so in the `tonic_validate/utils/telemetry.py` file
+We also generate a random UUID to help us figure out how many users are using the product. This UUID is linked to your Validate account only to help track who is using the SDK and UI at once and to get user counts. If you want to see how we implemented telemetry, you can do so in the `tonic_validate/utils/telemetry.py` file
 
 If you wish to opt out of telemetry, you only need to set the `TONIC_VALIDATE_DO_NOT_TRACK` environment variable to `True`.
 

--- a/tonic_validate/classes/__init__.py
+++ b/tonic_validate/classes/__init__.py
@@ -2,6 +2,7 @@ from .benchmark import Benchmark, BenchmarkItem
 from .llm_response import LLMResponse
 from .run import Run, RunData
 from .exceptions import ContextLengthException
+from .user_info import UserInfo
 
 __all__ = [
     "Benchmark",
@@ -10,4 +11,5 @@ __all__ = [
     "Run",
     "RunData",
     "ContextLengthException",
+    "UserInfo",
 ]

--- a/tonic_validate/classes/user_info.py
+++ b/tonic_validate/classes/user_info.py
@@ -1,0 +1,6 @@
+from typing import TypedDict
+
+
+class UserInfo(TypedDict):
+    user_id: str
+    linked: bool

--- a/tonic_validate/utils/telemetry.py
+++ b/tonic_validate/utils/telemetry.py
@@ -1,6 +1,8 @@
+import json
 import os
-from typing import List
+from typing import List, Optional
 import uuid
+from tonic_validate.classes.user_info import UserInfo
 from tonic_validate.config import (
     TONIC_VALIDATE_TELEMETRY_URL,
     TONIC_VALIDATE_DO_NOT_TRACK,
@@ -12,28 +14,29 @@ APP_DIR_NAME = "tonic-validate"
 
 
 class Telemetry:
-    def __init__(self):
-        self.http_client = HttpClient(TONIC_VALIDATE_TELEMETRY_URL)
+    def __init__(self, api_key: Optional[str] = None):
+        self.http_client = HttpClient(TONIC_VALIDATE_TELEMETRY_URL, api_key)
 
-    def get_user(self) -> str:
+    def get_user(self) -> UserInfo:
         app_dir_path = user_data_dir(appname=APP_DIR_NAME)
-        user_id_path = os.path.join(app_dir_path, "user.txt")
+        user_id_path = os.path.join(app_dir_path, "user.json")
         # check if user_id exists else we create a new uuid and write it to the file
         if os.path.exists(user_id_path):
             with open(user_id_path, "r") as f:
-                user_id = f.read()
+                user_info = json.load(f)
         else:
-            user_id = str(uuid.uuid4())
+            user_info: UserInfo = {"user_id": str(uuid.uuid4()), "linked": False}
+            json_info = json.dumps(user_info)
             # create the directory if it does not exist
             os.makedirs(app_dir_path, exist_ok=True)
             with open(user_id_path, "w") as f:
-                f.write(user_id)
-        return user_id
+                f.write(json_info)
+        return user_info
 
     def log_run(self, num_of_questions: int, metrics: List[str]):
         if TONIC_VALIDATE_DO_NOT_TRACK:
             return
-        user_id = self.get_user()
+        user_id = self.get_user()["user_id"]
         self.http_client.http_post(
             "/runs",
             data={
@@ -47,9 +50,28 @@ class Telemetry:
     def log_benchmark(self, num_of_questions: int):
         if TONIC_VALIDATE_DO_NOT_TRACK:
             return
-        user_id = self.get_user()
+        user_id = self.get_user()["user_id"]
         self.http_client.http_post(
             "/benchmarks",
             data={"user_id": user_id, "num_of_questions": num_of_questions},
             timeout=5,
         )
+
+    def link_user(self):
+        if TONIC_VALIDATE_DO_NOT_TRACK:
+            return
+        telemetry_user = self.get_user()
+        if telemetry_user["linked"]:
+            return
+        self.http_client.http_post(
+            "/users/link",
+            data={"telemetry_user_id": telemetry_user["user_id"]},
+            timeout=5,
+        )
+        # Write the linked user to the file
+        telemetry_user["linked"] = True
+        app_dir_path = user_data_dir(appname=APP_DIR_NAME)
+        user_id_path = os.path.join(app_dir_path, "user.json")
+        json_info = json.dumps(telemetry_user)
+        with open(user_id_path, "w") as f:
+            f.write(json_info)

--- a/tonic_validate/validate_api.py
+++ b/tonic_validate/validate_api.py
@@ -30,9 +30,9 @@ class ValidateApi:
                 )
                 raise Exception(exception_message)
         self.client = HttpClient(TONIC_VALIDATE_BASE_URL, api_key)
-        self.telemetry = Telemetry(api_key)
         try:
-            self.telemetry.link_user()
+            telemetry = Telemetry(api_key)
+            telemetry.link_user()
         except Exception as _:
             pass
 

--- a/tonic_validate/validate_api.py
+++ b/tonic_validate/validate_api.py
@@ -4,6 +4,7 @@ from tonic_validate.classes.run import Run
 from tonic_validate.config import TONIC_VALIDATE_API_KEY, TONIC_VALIDATE_BASE_URL
 
 from tonic_validate.utils.http_client import HttpClient
+from tonic_validate.utils.telemetry import Telemetry
 
 
 class ValidateApi:
@@ -29,6 +30,11 @@ class ValidateApi:
                 )
                 raise Exception(exception_message)
         self.client = HttpClient(TONIC_VALIDATE_BASE_URL, api_key)
+        self.telemetry = Telemetry(api_key)
+        try:
+            self.telemetry.link_user()
+        except Exception as _:
+            pass
 
     def upload_run(
         self, project_id: str, run: Run, run_metadata: Dict[str, str] = {}


### PR DESCRIPTION
After adding in telemetry, we realized that it was more practical to link the random user ids generated locally for telemetry to the web UI user ids IF a person is using both the SDK and web ui. This helps us figure out who is using the web ui and sdk at once and who isn't. It does not give any extra info to us than we had before. It solely is there to help us figure out who is and isn't using the web UI