### PR TITLE
Fix imports to include new classes

### DIFF
--- a/tonic_validate/__init__.py
+++ b/tonic_validate/__init__.py
@@ -1,6 +1,15 @@
 from .validate_api import ValidateApi
 from .validate_scorer import ValidateScorer
-from .classes import Benchmark, BenchmarkItem, LLMResponse, Run, RunData
+from .classes import (
+    Benchmark,
+    BenchmarkItem,
+    LLMResponse,
+    CallbackLLMResponse,
+    Run,
+    RunData,
+    ContextLengthException,
+    UserInfo,
+)
 
 __all__ = [
     "ValidateApi",
@@ -8,6 +17,9 @@ __all__ = [
     "Benchmark",
     "BenchmarkItem",
     "LLMResponse",
+    "CallbackLLMResponse",
     "Run",
     "RunData",
+    "ContextLengthException",
+    "UserInfo",
 ]

--- a/tonic_validate/classes/__init__.py
+++ b/tonic_validate/classes/__init__.py
@@ -1,5 +1,5 @@
 from .benchmark import Benchmark, BenchmarkItem
-from .llm_response import LLMResponse
+from .llm_response import LLMResponse, CallbackLLMResponse
 from .run import Run, RunData
 from .exceptions import ContextLengthException
 from .user_info import UserInfo
@@ -8,6 +8,7 @@ __all__ = [
     "Benchmark",
     "BenchmarkItem",
     "LLMResponse",
+    "CallbackLLMResponse",
     "Run",
     "RunData",
     "ContextLengthException",


### PR DESCRIPTION
We have added several new classes like `CallbackLLMResponse` which aren't exported by our `__init__.py` files. We should fix this to export them to make it easier to import these classes.