### PR TITLE
Add CI/CD detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Tonic Validate collects minimal telemetry to help us figure out what users want 
 * What metrics were used for a run
 * Number of questions in a run
 * Number of questions in a benchmark
+* If the run / benchmark was created in CI/CD
 
-We do **NOT** track things such as the contents of the questions / answers, your scores, or any other sensitive information.
+We do **NOT** track things such as the contents of the questions / answers, your scores, or any other sensitive information. For detecting CI/CD, we only check for common environment variables in different CI/CD environments. We do not log the values of these environment variables.
 
 We also generate a random UUID to help us figure out how many users are using the product. This UUID is linked to your Validate account only to help track who is using the SDK and UI at once and to get user counts. If you want to see how we implemented telemetry, you can do so in the `tonic_validate/utils/telemetry.py` file
 

--- a/tonic_validate/classes/benchmark.py
+++ b/tonic_validate/classes/benchmark.py
@@ -23,14 +23,13 @@ class Benchmark:
         self.items: List[BenchmarkItem] = []
         self.telemetry = Telemetry()
 
-        if answers is None:
-            for question in questions:
-                self.items.append(BenchmarkItem(question))
-            return
+        benchmark_answers = answers
+        if benchmark_answers is None:
+            benchmark_answers = [None] * len(questions)
 
-        if len(questions) != len(answers):
+        if len(questions) != len(benchmark_answers):
             raise ValueError("Questions and answers must be the same length")
-        for question, answer in zip(questions, answers):
+        for question, answer in zip(questions, benchmark_answers):
             self.items.append(BenchmarkItem(question, answer))
 
         try:

--- a/tonic_validate/utils/telemetry.py
+++ b/tonic_validate/utils/telemetry.py
@@ -12,6 +12,16 @@ from appdirs import user_data_dir
 
 APP_DIR_NAME = "tonic-validate"
 
+# List of CI/CD environment variables
+# 1. Github Actions: GITHUB_ACTIONS
+# 2  Gitlab CI/CD: GITLAB_CI
+# 3. Azure devops: TF_BUILD
+# 4. CircleCI: CI
+# 5. Jenkins: JENKINS_URL
+# 6. TravisCI: CI
+# 7. Bitbucket: CI
+env_vars = ["GITHUB_ACTIONS", "GITLAB_CI", "TF_BUILD", "CI", "JENKINS_URL"]
+
 
 class Telemetry:
     def __init__(self, api_key: Optional[str] = None):
@@ -33,6 +43,12 @@ class Telemetry:
                 f.write(json_info)
         return user_info
 
+    def __is_ci(self):
+        for var in env_vars:
+            if os.environ.get(var):
+                return True
+        return False
+
     def log_run(self, num_of_questions: int, metrics: List[str]):
         if TONIC_VALIDATE_DO_NOT_TRACK:
             return
@@ -43,6 +59,7 @@ class Telemetry:
                 "user_id": user_id,
                 "num_of_questions": num_of_questions,
                 "metrics": metrics,
+                "is_ci": self.__is_ci(),
             },
             timeout=5,
         )
@@ -53,7 +70,11 @@ class Telemetry:
         user_id = self.get_user()["user_id"]
         self.http_client.http_post(
             "/benchmarks",
-            data={"user_id": user_id, "num_of_questions": num_of_questions},
+            data={
+                "user_id": user_id,
+                "num_of_questions": num_of_questions,
+                "is_ci": self.__is_ci(),
+            },
             timeout=5,
         )
 


### PR DESCRIPTION
This pull request adds CI/CD detection to help us distinguish between CI runs and local runs. This allows us to filter through CI usage to get a better idea of how many people are using Tonic Validate. The way the CI/CD detection works is it checks for common environment variables in various CI/CD platforms. If the environment variable exists, then we tell the telemetry that Tonic Validate is running in CI/CD. The CI/CD detection does NOT log the value of the environment variables it checks.