### PR TITLE
Fix config running on import

### DIFF
--- a/tonic_validate/config.py
+++ b/tonic_validate/config.py
@@ -1,18 +1,21 @@
 import os
 from dotenv import load_dotenv
 
-load_dotenv()
 
-TONIC_VALIDATE_API_KEY = os.getenv(
-    "TONIC_VALIDATE_API_KEY",
-)
-TONIC_VALIDATE_BASE_URL = os.getenv(
-    "TONIC_VALIDATE_BASE_URL", "https://validate.tonic.ai/api/v1"
-)
-TONIC_VALIDATE_TELEMETRY_URL = os.getenv(
-    "TONIC_VALIDATE_TELEMETRY_URL", "https://telemetry.tonic.ai/validate"
-)
-TONIC_VALIDATE_DO_NOT_TRACK = os.getenv(
-    "TONIC_VALIDATE_DO_NOT_TRACK", "false"
-).lower() in ("true", "1", "t")
-TONIC_VALIDATE_GITHUB_ACTION = os.getenv("TONIC_VALIDATE_GITHUB_ACTION")
+class Config:
+    def __init__(self) -> None:
+        load_dotenv()
+
+        self.TONIC_VALIDATE_API_KEY = os.getenv(
+            "TONIC_VALIDATE_API_KEY",
+        )
+        self.TONIC_VALIDATE_BASE_URL = os.getenv(
+            "TONIC_VALIDATE_BASE_URL", "https://validate.tonic.ai/api/v1"
+        )
+        self.TONIC_VALIDATE_TELEMETRY_URL = os.getenv(
+            "TONIC_VALIDATE_TELEMETRY_URL", "https://telemetry.tonic.ai/validate"
+        )
+        self.TONIC_VALIDATE_DO_NOT_TRACK = os.getenv(
+            "TONIC_VALIDATE_DO_NOT_TRACK", "false"
+        ).lower() in ("true", "1", "t")
+        self.TONIC_VALIDATE_GITHUB_ACTION = os.getenv("TONIC_VALIDATE_GITHUB_ACTION")

--- a/tonic_validate/utils/telemetry.py
+++ b/tonic_validate/utils/telemetry.py
@@ -3,11 +3,7 @@ import os
 from typing import List, Optional
 import uuid
 from tonic_validate.classes.user_info import UserInfo
-from tonic_validate.config import (
-    TONIC_VALIDATE_GITHUB_ACTION,
-    TONIC_VALIDATE_TELEMETRY_URL,
-    TONIC_VALIDATE_DO_NOT_TRACK,
-)
+from tonic_validate.config import Config
 from tonic_validate.utils.http_client import HttpClient
 from appdirs import user_data_dir
 
@@ -26,7 +22,8 @@ env_vars = ["GITHUB_ACTIONS", "GITLAB_CI", "TF_BUILD", "CI", "JENKINS_URL"]
 
 class Telemetry:
     def __init__(self, api_key: Optional[str] = None):
-        self.http_client = HttpClient(TONIC_VALIDATE_TELEMETRY_URL, api_key)
+        self.config = Config()
+        self.http_client = HttpClient(self.config.TONIC_VALIDATE_TELEMETRY_URL, api_key)
 
     def get_user(self) -> UserInfo:
         app_dir_path = user_data_dir(appname=APP_DIR_NAME)
@@ -51,7 +48,7 @@ class Telemetry:
         return False
 
     def log_run(self, num_of_questions: int, metrics: List[str]):
-        if TONIC_VALIDATE_DO_NOT_TRACK:
+        if self.config.TONIC_VALIDATE_DO_NOT_TRACK:
             return
         user_id = self.get_user()["user_id"]
         self.http_client.http_post(
@@ -61,13 +58,13 @@ class Telemetry:
                 "num_of_questions": num_of_questions,
                 "metrics": metrics,
                 "is_ci": self.__is_ci(),
-                "validate_gh_action": TONIC_VALIDATE_GITHUB_ACTION,
+                "validate_gh_action": self.config.TONIC_VALIDATE_GITHUB_ACTION,
             },
             timeout=5,
         )
 
     def log_benchmark(self, num_of_questions: int):
-        if TONIC_VALIDATE_DO_NOT_TRACK:
+        if self.config.TONIC_VALIDATE_DO_NOT_TRACK:
             return
         user_id = self.get_user()["user_id"]
         self.http_client.http_post(
@@ -76,13 +73,13 @@ class Telemetry:
                 "user_id": user_id,
                 "num_of_questions": num_of_questions,
                 "is_ci": self.__is_ci(),
-                "validate_gh_action": TONIC_VALIDATE_GITHUB_ACTION,
+                "validate_gh_action": self.config.TONIC_VALIDATE_GITHUB_ACTION,
             },
             timeout=5,
         )
 
     def link_user(self):
-        if TONIC_VALIDATE_DO_NOT_TRACK:
+        if self.config.TONIC_VALIDATE_DO_NOT_TRACK:
             return
         telemetry_user = self.get_user()
         if telemetry_user["linked"]:

--- a/tonic_validate/validate_api.py
+++ b/tonic_validate/validate_api.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Dict
 from tonic_validate.classes.benchmark import Benchmark
 from tonic_validate.classes.run import Run
-from tonic_validate.config import TONIC_VALIDATE_API_KEY, TONIC_VALIDATE_BASE_URL
+from tonic_validate.config import Config
 
 from tonic_validate.utils.http_client import HttpClient
 from tonic_validate.utils.telemetry import Telemetry
@@ -21,15 +21,16 @@ class ValidateApi:
         self,
         api_key: Optional[str] = None,
     ):
+        self.config = Config()
         if api_key is None:
-            api_key = TONIC_VALIDATE_API_KEY
+            api_key = self.config.TONIC_VALIDATE_API_KEY
             if api_key is None:
                 exception_message = (
                     "No api key provided. Please provide an api key or set "
                     "TONIC_VALIDATE_API_KEY environment variable."
                 )
                 raise Exception(exception_message)
-        self.client = HttpClient(TONIC_VALIDATE_BASE_URL, api_key)
+        self.client = HttpClient(self.config.TONIC_VALIDATE_BASE_URL, api_key)
         try:
             telemetry = Telemetry(api_key)
             telemetry.link_user()


### PR DESCRIPTION
Right now, when setting up the env vars in config it happens to run on import and not when the classes using the config are instantiated. E.G. when doing `from tonic_validate import Benchmark, ValidateApi, ValidateScorer` then `config.py` will run which sets up the env vars for validate prematurely.

This pr fixes it by running only when a class needing the config is instantiated. 