### PR TITLE
Allow nested metadata

### DIFF
--- a/tonic_validate/__init__.py
+++ b/tonic_validate/__init__.py
@@ -9,6 +9,7 @@ from .classes import (
     RunData,
     ContextLengthException,
     UserInfo,
+    MetadataDict,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "RunData",
     "ContextLengthException",
     "UserInfo",
+    "MetadataDict",
 ]

--- a/tonic_validate/classes/__init__.py
+++ b/tonic_validate/classes/__init__.py
@@ -1,6 +1,6 @@
 from .benchmark import Benchmark, BenchmarkItem
 from .llm_response import LLMResponse, CallbackLLMResponse
-from .run import Run, RunData
+from .run import Run, RunData, MetadataDict
 from .exceptions import ContextLengthException
 from .user_info import UserInfo
 
@@ -13,4 +13,5 @@ __all__ = [
     "RunData",
     "ContextLengthException",
     "UserInfo",
+    "MetadataDict",
 ]

--- a/tonic_validate/classes/run.py
+++ b/tonic_validate/classes/run.py
@@ -6,6 +6,9 @@ from uuid import UUID
 logger = logging.getLogger()
 
 
+MetadataDict = Dict[str, Union[str, Dict[str, str]]]
+
+
 @dataclass
 class RunData:
     scores: Dict[str, Union[float, None]]


### PR DESCRIPTION
This pr allows for nested metadata (one level deep only). This way someone can pass in metadata for our popover like so

```
api.upload_run(project_id, run, {
    "chunk_size": "256",
    "popover": {
        "commit_id": "1234"
    }
})
```