### PR TITLE
Add LatencyMetric class

### DIFF
--- a/tonic_validate/classes/llm_response.py
+++ b/tonic_validate/classes/llm_response.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, TypedDict
+from typing import List, Optional, TypedDict
 
 from tonic_validate.classes.benchmark import BenchmarkItem
 
@@ -9,6 +9,7 @@ class LLMResponse:
     llm_answer: str
     llm_context_list: List[str]
     benchmark_item: BenchmarkItem
+    run_time: Optional[float] = None
 
 
 class CallbackLLMResponse(TypedDict):

--- a/tonic_validate/metrics/__init__.py
+++ b/tonic_validate/metrics/__init__.py
@@ -4,6 +4,7 @@ from .answer_similarity_metric import AnswerSimilarityMetric
 from .augmentation_accuracy_metric import AugmentationAccuracyMetric
 from .augmentation_precision_metric import AugmentationPrecisionMetric
 from .retrieval_precision_metric import RetrievalPrecisionMetric
+from .latency_metric import LatencyMetric
 
 __all__ = [
     "AnswerConsistencyBinaryMetric",
@@ -12,4 +13,5 @@ __all__ = [
     "AugmentationAccuracyMetric",
     "AugmentationPrecisionMetric",
     "RetrievalPrecisionMetric",
+    "LatencyMetric",
 ]

--- a/tonic_validate/metrics/latency_metric.py
+++ b/tonic_validate/metrics/latency_metric.py
@@ -1,0 +1,30 @@
+import logging
+from tonic_validate.classes.llm_response import LLMResponse
+from tonic_validate.metrics.metric import Metric
+from tonic_validate.services.openai_service import OpenAIService
+
+logger = logging.getLogger()
+
+
+class LatencyMetric(Metric):
+    name: str = "latency_metric"
+
+    def __init__(self, target_time: float = 5.0) -> None:
+        """
+        Create a LatencyMetric.
+
+        Parameters
+        ----------
+        target_time: float
+            The target time for the model to complete the request in seconds.
+        """
+        self.target_time = target_time
+
+    def score(self, llm_response: LLMResponse, openai_service: OpenAIService) -> float:
+        # Check that llm_response.run_time is not None
+        if llm_response.run_time is None:
+            raise ValueError("No run time provided in LLMResponse")
+        # Find percentage of target time
+        if llm_response.run_time == 0:
+            return 1.0
+        return min(1.0, self.target_time / llm_response.run_time)

--- a/tonic_validate/validate_scorer.py
+++ b/tonic_validate/validate_scorer.py
@@ -19,6 +19,7 @@ from tonic_validate.services.openai_service import OpenAIService
 import tiktoken
 from tonic_validate.utils.telemetry import Telemetry
 from tqdm import tqdm
+import time
 
 logger = logging.getLogger()
 
@@ -203,11 +204,17 @@ class ValidateScorer:
         responses: List[LLMResponse] = []
 
         def create_response(item: BenchmarkItem) -> LLMResponse:
+            # Time the callback
+            start_time = time.time()
+            callback_response = callback(item.question)
+            end_time = time.time()
+            run_time = end_time - start_time
             callback_response = callback(item.question)
             return LLMResponse(
                 callback_response["llm_answer"],
                 callback_response["llm_context_list"],
                 item,
+                run_time,
             )
 
         with ThreadPoolExecutor(max_workers=callback_parallelism) as executor:


### PR DESCRIPTION
This pull request adds a new `LatencyMetric` to Validate. The `LatencyMetric` class is a metric used to measure the latency of the model's response time. It calculates the percentage of the target time that the model takes to complete a request. This metric can be used to evaluate the performance of the model in terms of response time.