### PR TITLE
Added new metrics to scan for PII in RAG Answer and RAG Context.

### DIFF
--- a/tonic_validate/metrics/__init__.py
+++ b/tonic_validate/metrics/__init__.py
@@ -13,6 +13,8 @@ from .regex_metric import RegexMetric
 from .response_length_metric import ResponseLengthMetric
 from .hate_speech_content_metric import HateSpeechContentMetric
 from .latency_metric import LatencyMetric
+from .context_contains_pii_metric import ContextContainsPiiMetric
+from .answer_contains_pii_metric import AnswerContainsPiiMetric
 
 __all__ = [
     "AnswerConsistencyBinaryMetric",
@@ -30,4 +32,6 @@ __all__ = [
     "ResponseLengthMetric",
     "HateSpeechContentMetric",
     "LatencyMetric",
+    "ContextContainsPiiMetric",
+    "AnswerContainsPiiMetric"
 ]

--- a/tonic_validate/metrics/answer_contains_pii_metric.py
+++ b/tonic_validate/metrics/answer_contains_pii_metric.py
@@ -1,4 +1,5 @@
 import os
+import requests
 from typing import List, Optional
 from tonic_validate.classes.llm_response import LLMResponse
 from tonic_validate.metrics.binary_metric import BinaryMetric
@@ -37,5 +38,8 @@ class AnswerContainsPiiMetric(BinaryMetric):
                 if d.label.lower() in self.pii_types:
                     return 1.0
             return 0.0
+        except requests.exceptions.HTTPError as e:
+             if e.response.status_code==401:
+                 raise ValueError('Cannot compute AnswerContainsPiiMetric. Your Textual API Key is INVALID.')
         except Exception:
             raise ValueError('Cannot compute AnswerContainsPiiMetric. Error occured communicating with Textual.  Please try again later or reach out via GitHub issues.')

--- a/tonic_validate/metrics/answer_contains_pii_metric.py
+++ b/tonic_validate/metrics/answer_contains_pii_metric.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from tonic_validate.classes.llm_response import LLMResponse
 from tonic_validate.metrics.binary_metric import BinaryMetric
 from tonic_validate.services.openai_service import OpenAIService
-from tonic_textual.api import TonicTextual
+
 
 class AnswerContainsPiiMetric(BinaryMetric):
     def __init__(self, pii_types: List[str], textual_api_key: Optional[str] = None):
@@ -21,25 +21,39 @@ class AnswerContainsPiiMetric(BinaryMetric):
         Your Textual API key.  This value is optional. It is preferred that you set TONIC_TEXTUAL_API_KEY via your ENVIRONMENT.
 
         """
+        try:
+            from tonic_textual.api import TonicTextual
+        except ImportError:
+            raise ImportError(
+                "You must install tonic-textual to use the AnswerContainsPiiMetric. You can install it via pip: pip install tonic-textual"
+            )
         self.pii_types = [p.lower() for p in pii_types]
         if textual_api_key is None:
             if os.getenv("TONIC_TEXTUAL_API_KEY") is None:
-                raise ValueError("You must set TONIC_TEXTUAL_API_KEY in your ENV or pass your Textual API key into the constructor.")
+                raise ValueError(
+                    "You must set TONIC_TEXTUAL_API_KEY in your ENV or pass your Textual API key into the constructor."
+                )
             self.textual = TonicTextual("https://textual.tonic.ai")
         else:
             self.textual = TonicTextual("https://textual.tonic.ai", textual_api_key)
 
         super().__init__("answer_contains_pii", self.metric_callback)
 
-    def metric_callback(self, llm_response: LLMResponse, openai_service: OpenAIService) -> float:
+    def metric_callback(
+        self, llm_response: LLMResponse, openai_service: OpenAIService
+    ) -> float:
         try:
-            response = self.textual.redact('\n'.join(llm_response.llm_context_list))
+            response = self.textual.redact("\n".join(llm_response.llm_context_list))
             for d in response.de_identify_results:
                 if d.label.lower() in self.pii_types:
                     return 1.0
             return 0.0
         except requests.exceptions.HTTPError as e:
-             if e.response.status_code==401:
-                 raise ValueError('Cannot compute AnswerContainsPiiMetric. Your Textual API Key is INVALID.')
+            if e.response.status_code == 401:
+                raise ValueError(
+                    "Cannot compute AnswerContainsPiiMetric. Your Textual API Key is INVALID."
+                )
         except Exception:
-            raise ValueError('Cannot compute AnswerContainsPiiMetric. Error occured communicating with Textual.  Please try again later or reach out via GitHub issues.')
+            raise ValueError(
+                "Cannot compute AnswerContainsPiiMetric. Error occured communicating with Textual.  Please try again later or reach out via GitHub issues."
+            )

--- a/tonic_validate/metrics/answer_contains_pii_metric.py
+++ b/tonic_validate/metrics/answer_contains_pii_metric.py
@@ -1,0 +1,38 @@
+from typing import List, Optional
+from tonic_validate.classes.llm_response import LLMResponse
+from tonic_validate.metrics.binary_metric import BinaryMetric
+from tonic_validate.services.openai_service import OpenAIService
+from tonic_textual.api import TonicTextual
+
+class AnswerContainsPiiMetric(BinaryMetric):
+    def __init__(self, pii_types: List[str], textual_api_key: Optional[str] = None):
+        """
+        Checks to see if PII is contained in the RAG provided answer.  The types of PII looked for are found in the pii_types list.
+
+        Parameters
+        ----------
+        pii_types: List[str]
+        The list of PII types which are looked for in the RAG answer.  The list of possible options are those available in via tonic-textual. Using this Metric requries a Tonic Textual API key.
+        You can create an API key for free at at https://textual.tonic.ai.  You can pass your API key into this constructor OR set TONIC_TEXTUAL_API_KEY in your ENVIRONMENT.
+
+        textual_api_key: Optional[str]
+        Your Textual API key.  This value is optional. It is preferred that you set TONIC_TEXTUAL_API_KEY via your ENVIRONMENT.
+
+        """
+        self.pii_types = [p.lower() for p in pii_types]
+        if textual_api_key is None:            
+            self.textual = TonicTextual("https://textual.tonic.ai")
+        else:
+            self.textual = TonicTextual("https://textual.tonic.ai", textual_api_key)
+
+        super().__init__("answer_contains_pii", self.metric_callback)
+
+    def metric_callback(self, llm_response: LLMResponse, openai_service: OpenAIService) -> float:
+        try:
+            response = self.textual.redact('\n'.join(llm_response.llm_context_list))
+            for d in response.de_identify_results:
+                if d.label.lower() in self.pii_types:
+                    return 1.0
+            return 0.0
+        except Exception:
+            raise ValueError('Cannot compute AnswerContainsPiiMetric. Error occured communicating with Textual.  Please try again later or reach out via GitHub issues.')

--- a/tonic_validate/metrics/answer_contains_pii_metric.py
+++ b/tonic_validate/metrics/answer_contains_pii_metric.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Optional
 from tonic_validate.classes.llm_response import LLMResponse
 from tonic_validate.metrics.binary_metric import BinaryMetric
@@ -20,7 +21,9 @@ class AnswerContainsPiiMetric(BinaryMetric):
 
         """
         self.pii_types = [p.lower() for p in pii_types]
-        if textual_api_key is None:            
+        if textual_api_key is None:
+            if os.getenv("TONIC_TEXTUAL_API_KEY") is None:
+                raise ValueError("You must set TONIC_TEXTUAL_API_KEY in your ENV or pass your Textual API key into the constructor.")
             self.textual = TonicTextual("https://textual.tonic.ai")
         else:
             self.textual = TonicTextual("https://textual.tonic.ai", textual_api_key)

--- a/tonic_validate/metrics/context_contains_pii_metric.py
+++ b/tonic_validate/metrics/context_contains_pii_metric.py
@@ -1,4 +1,5 @@
 import os
+import requests
 from typing import List, Optional
 from tonic_validate.classes.llm_response import LLMResponse
 from tonic_validate.metrics.binary_metric import BinaryMetric
@@ -38,6 +39,9 @@ class ContextContainsPiiMetric(BinaryMetric):
                 if d.label.lower() in self.pii_types:
                     return 1.0
             return 0.0
+        except requests.exceptions.HTTPError as e:
+             if e.response.status_code==401:
+                 raise ValueError('Cannot compute ContextContainsPiiMetric. Your Textual API Key is INVALID.')        
         except Exception:
             raise ValueError('Cannot compute ContextContainsPiiMetric. Error occured communicating with Textual.  Please try again later or reach out via GitHub issues.')
 

--- a/tonic_validate/metrics/context_contains_pii_metric.py
+++ b/tonic_validate/metrics/context_contains_pii_metric.py
@@ -1,0 +1,40 @@
+from typing import List, Optional
+from tonic_validate.classes.llm_response import LLMResponse
+from tonic_validate.metrics.binary_metric import BinaryMetric
+from tonic_validate.services.openai_service import OpenAIService
+from tonic_textual.api import TonicTextual
+
+class ContextContainsPiiMetric(BinaryMetric):
+    def __init__(self, pii_types: List[str], textual_api_key: Optional[str] = None):
+        """
+        Checks to see if PII is contained in the RAG provided context.  The types of PII looked for are found in the pii_types list.
+
+        Parameters
+        ----------
+        pii_types: List[str]
+        The list of PII types which are looked for in the RAG context.  The list of possible options are those available in via tonic-textual. Using this Metric requries a Tonic Textual API key.
+        You can create an API key for free at at https://textual.tonic.ai.  You can pass your API key into this constructor OR set TONIC_TEXTUAL_API_KEY in your ENVIRONMENT.
+
+        textual_api_key: Optional[str]
+        Your Textual API key.  This value is optional. It is preferred that you set TONIC_TEXTUAL_API_KEY via your ENVIRONMENT.
+
+        """
+        self.pii_types = [p.lower() for p in pii_types]
+        if textual_api_key is None:            
+            self.textual = TonicTextual("https://textual.tonic.ai")
+        else:
+            self.textual = TonicTextual("https://textual.tonic.ai", textual_api_key)
+
+        super().__init__("context_contains_pii", self.metric_callback)
+
+
+    def metric_callback(self, llm_response: LLMResponse, openai_service: OpenAIService) -> float:
+        try:      
+            response = self.textual.redact('\n'.join(llm_response.llm_context_list))
+            for d in response.de_identify_results:
+                if d.label.lower() in self.pii_types:
+                    return 1.0
+            return 0.0
+        except Exception:
+            raise ValueError('Cannot compute ContextContainsPiiMetric. Error occured communicating with Textual.  Please try again later or reach out via GitHub issues.')
+

--- a/tonic_validate/metrics/context_contains_pii_metric.py
+++ b/tonic_validate/metrics/context_contains_pii_metric.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from tonic_validate.classes.llm_response import LLMResponse
 from tonic_validate.metrics.binary_metric import BinaryMetric
 from tonic_validate.services.openai_service import OpenAIService
-from tonic_textual.api import TonicTextual
+
 
 class ContextContainsPiiMetric(BinaryMetric):
     def __init__(self, pii_types: List[str], textual_api_key: Optional[str] = None):
@@ -21,27 +21,39 @@ class ContextContainsPiiMetric(BinaryMetric):
         Your Textual API key.  This value is optional. It is preferred that you set TONIC_TEXTUAL_API_KEY via your ENVIRONMENT.
 
         """
+        try:
+            from tonic_textual.api import TonicTextual
+        except ImportError:
+            raise ImportError(
+                "You must install tonic-textual to use the ContextContainsPiiMetric. You can install it via pip: pip install tonic-textual"
+            )
         self.pii_types = [p.lower() for p in pii_types]
         if textual_api_key is None:
             if os.getenv("TONIC_TEXTUAL_API_KEY") is None:
-                raise ValueError("You must set TONIC_TEXTUAL_API_KEY in your ENV or pass your Textual API key into the constructor.")
+                raise ValueError(
+                    "You must set TONIC_TEXTUAL_API_KEY in your ENV or pass your Textual API key into the constructor."
+                )
             self.textual = TonicTextual("https://textual.tonic.ai")
         else:
             self.textual = TonicTextual("https://textual.tonic.ai", textual_api_key)
 
         super().__init__("context_contains_pii", self.metric_callback)
 
-
-    def metric_callback(self, llm_response: LLMResponse, openai_service: OpenAIService) -> float:
-        try:      
-            response = self.textual.redact('\n'.join(llm_response.llm_context_list))
+    def metric_callback(
+        self, llm_response: LLMResponse, openai_service: OpenAIService
+    ) -> float:
+        try:
+            response = self.textual.redact("\n".join(llm_response.llm_context_list))
             for d in response.de_identify_results:
                 if d.label.lower() in self.pii_types:
                     return 1.0
             return 0.0
         except requests.exceptions.HTTPError as e:
-             if e.response.status_code==401:
-                 raise ValueError('Cannot compute ContextContainsPiiMetric. Your Textual API Key is INVALID.')        
+            if e.response.status_code == 401:
+                raise ValueError(
+                    "Cannot compute ContextContainsPiiMetric. Your Textual API Key is INVALID."
+                )
         except Exception:
-            raise ValueError('Cannot compute ContextContainsPiiMetric. Error occured communicating with Textual.  Please try again later or reach out via GitHub issues.')
-
+            raise ValueError(
+                "Cannot compute ContextContainsPiiMetric. Error occured communicating with Textual.  Please try again later or reach out via GitHub issues."
+            )

--- a/tonic_validate/metrics/context_contains_pii_metric.py
+++ b/tonic_validate/metrics/context_contains_pii_metric.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Optional
 from tonic_validate.classes.llm_response import LLMResponse
 from tonic_validate.metrics.binary_metric import BinaryMetric
@@ -20,7 +21,9 @@ class ContextContainsPiiMetric(BinaryMetric):
 
         """
         self.pii_types = [p.lower() for p in pii_types]
-        if textual_api_key is None:            
+        if textual_api_key is None:
+            if os.getenv("TONIC_TEXTUAL_API_KEY") is None:
+                raise ValueError("You must set TONIC_TEXTUAL_API_KEY in your ENV or pass your Textual API key into the constructor.")
             self.textual = TonicTextual("https://textual.tonic.ai")
         else:
             self.textual = TonicTextual("https://textual.tonic.ai", textual_api_key)


### PR DESCRIPTION
This PR adds two new metrics.  

**ContextContainsPiiMetric** - Looks for PII in the RAG generated context
**AnswerContainsPiiMetric** - Looks for PII in the RAG generated answer

Both PII metrics call into [Tonic Textual](https://textual.tonic.ai) and require an API key.