### PR TITLE
Speed up uploads

### DIFF
--- a/tonic_validate/validate_api.py
+++ b/tonic_validate/validate_api.py
@@ -55,16 +55,13 @@ class ValidateApi:
         processed_run_metadata = {
             str(key): str(value) for key, value in run_metadata.items()
         }
-        run_response = self.client.http_post(f"/projects/{project_id}/runs")
-        run_response = self.client.http_put(
-            f"/projects/{project_id}/runs/{run_response['id']}",
-            data={"run_metadata": processed_run_metadata},
+        run_response = self.client.http_post(
+            f"/projects/{project_id}/runs",
+            data={
+                "run_metadata": processed_run_metadata,
+                "data": [run_data.to_dict() for run_data in run.run_data],
+            },
         )
-        for run_data in run.run_data:
-            _ = self.client.http_post(
-                f"/projects/{project_id}/runs/{run_response['id']}/logs",
-                data=run_data.to_dict(),
-            )
         return run_response["id"]
 
     def get_benchmark(self, benchmark_id: str) -> Benchmark:

--- a/tonic_validate/validate_api.py
+++ b/tonic_validate/validate_api.py
@@ -56,7 +56,7 @@ class ValidateApi:
             str(key): str(value) for key, value in run_metadata.items()
         }
         run_response = self.client.http_post(
-            f"/projects/{project_id}/runs",
+            f"/projects/{project_id}/runs/with_data",
             data={
                 "run_metadata": processed_run_metadata,
                 "data": [run_data.to_dict() for run_data in run.run_data],


### PR DESCRIPTION
This PR speeds up the uploads via allowing all logs to be uploaded at once as opposed to bit by bit. On a run of 50 questions, the speed of uploading goes from 14.3 s/upload to 2.2 s/upload