### PR TITLE
Fix Answer Contains PII

### DIFF
--- a/tonic_validate/metrics/answer_contains_pii_metric.py
+++ b/tonic_validate/metrics/answer_contains_pii_metric.py
@@ -43,7 +43,7 @@ class AnswerContainsPiiMetric(BinaryMetric):
         self, llm_response: LLMResponse, openai_service: OpenAIService
     ) -> bool:
         try:
-            response = self.textual.redact("\n".join(llm_response.llm_context_list))
+            response = self.textual.redact(llm_response.llm_answer)
             for d in response.de_identify_results:
                 if d.label.lower() in self.pii_types:
                     return True


### PR DESCRIPTION
Code from the Context Contains PII metric accidentally made it's way into answer contains PII. This fixes it by checking llm_answer instead of context