### PR TITLE
Added type validation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1059,4 +1059,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0.0"
-content-hash = "0ee572350052c722a2a77a3bf45f2673ce78363cfab1a1c5d7f5610fd5ca634f"
+content-hash = "1a841f87d4d82e6a1fbea0edb903d3d5da2086f39d2e87acab9ec246cdeb8598"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ appdirs = "^1.4.4"
 python-dotenv = "^1.0.1"
 tqdm = "^4.66.2"
 async-lru = "^2.0.4"
+pydantic = "^2.6.4"
+typing-extensions = "^4.10.0"
 
 [tool.poetry.group.dev.dependencies]
 sphinx = "^7.0.0"

--- a/tonic_validate/classes/benchmark.py
+++ b/tonic_validate/classes/benchmark.py
@@ -1,5 +1,6 @@
 from typing import Iterator, List, Optional
-from dataclasses import dataclass
+from pydantic import ConfigDict, validate_call
+from pydantic.dataclasses import dataclass
 from uuid import UUID
 
 from tonic_validate.utils.telemetry import Telemetry
@@ -26,6 +27,7 @@ class BenchmarkItem:
 
 
 class Benchmark:
+    @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def __init__(
         self,
         questions: List[str],
@@ -55,7 +57,7 @@ class Benchmark:
         if len(questions) != len(benchmark_answers):
             raise ValueError("Questions and answers must be the same length")
         for question, answer in zip(questions, benchmark_answers):
-            self.items.append(BenchmarkItem(question, answer))
+            self.items.append(BenchmarkItem(question=question, answer=answer))
 
         try:
             self.telemetry.log_benchmark(len(questions))

--- a/tonic_validate/classes/llm_response.py
+++ b/tonic_validate/classes/llm_response.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass
-from typing import List, Optional, TypedDict
+from pydantic.dataclasses import dataclass
+from typing import List, Optional
+from typing_extensions import TypedDict
 
 from tonic_validate.classes.benchmark import BenchmarkItem
 

--- a/tonic_validate/classes/run.py
+++ b/tonic_validate/classes/run.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Any, List, Optional, Dict, Union
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 from uuid import UUID
 
 logger = logging.getLogger()

--- a/tonic_validate/validate_api.py
+++ b/tonic_validate/validate_api.py
@@ -1,4 +1,5 @@
 from typing import List, Optional, Dict
+from pydantic import ConfigDict, validate_call
 from tonic_validate.classes.benchmark import Benchmark
 from tonic_validate.classes.run import Run
 from tonic_validate.config import Config
@@ -8,6 +9,7 @@ from tonic_validate.utils.telemetry import Telemetry
 
 
 class ValidateApi:
+    @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def __init__(
         self,
         api_key: Optional[str] = None,
@@ -36,6 +38,7 @@ class ValidateApi:
         except Exception as _:
             pass
 
+    @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def upload_run(
         self, project_id: str, run: Run, run_metadata: Dict[str, str] = {}
     ) -> str:
@@ -64,6 +67,7 @@ class ValidateApi:
         )
         return run_response["id"]
 
+    @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def get_benchmark(self, benchmark_id: str) -> Benchmark:
         """Get a Tonic Validate benchmark by its ID.
 
@@ -85,6 +89,7 @@ class ValidateApi:
             answers += [benchmark_item_response["answer"]]
         return Benchmark(questions, answers, benchmark_response["name"])
 
+    @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def new_benchmark(self, benchmark: Benchmark, benchmark_name: str) -> str:
         """Create a new Tonic Validate benchmark.
 


### PR DESCRIPTION
This PR adds checking for types to prevent confusion when people accidentally put the wrong types into the SDK (e.g. inputting a string instead of a list into the LLM Response)