### PR TITLE
Added field to store the llm used for the eval.

### DIFF
--- a/tonic_validate/classes/run.py
+++ b/tonic_validate/classes/run.py
@@ -58,12 +58,15 @@ class Run:
         The overall scores for the run
     run_data: List[RunData]
         The run data
+    llm_evaluator: Optional[str]
+        The name of the language model evaluator
     id: Optional[UUID]
         The identifier of the run
     """
 
     overall_scores: Dict[str, float]
     run_data: List[RunData]
+    llm_evaluator: Optional[str]
     id: Optional[UUID]
 
     def to_df(self):

--- a/tonic_validate/validate_api.py
+++ b/tonic_validate/validate_api.py
@@ -56,6 +56,8 @@ class ValidateApi:
         tags : Optional[List[str]]
             A list of tags which can be used to identify this run.  Tags will be rendered in the UI and can also make run searchable.
         """
+        if "llm_evaluator" not in run_metadata:
+            run_metadata["llm_evaluator"] = run.llm_evaluator
         run_response = self.client.http_post(
             f"/projects/{project_id}/runs/with_data",
             data={

--- a/tonic_validate/validate_scorer.py
+++ b/tonic_validate/validate_scorer.py
@@ -197,7 +197,7 @@ class ValidateScorer:
             metric: total / num_scores[metric] for metric, total in total_scores.items()
         }
 
-        return Run(overall_scores=overall_scores, run_data=run_data, id=None)
+        return Run(overall_scores=overall_scores, run_data=run_data, llm_evaluator=self.model_evaluator, id=None)
 
     @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def score_responses(


### PR DESCRIPTION
Fixes #33 by adding a way to see the LLM model that is used. Makes sure that the llm_evaluator field is not set in the metatdata and then sets it.

Updated the Run class to store the llm string.
Updated the validate_api class to store the llm string in the metadata that is sent. 
Updated the validate_scorer class to include the evaluator_model in the Run.
