### PR TITLE
Allow custom base url for scoring models

### DIFF
--- a/tonic_validate/services/openai_service.py
+++ b/tonic_validate/services/openai_service.py
@@ -58,7 +58,7 @@ class OpenAIService:
             )
         else:
             raise Exception(
-                "OPENAI_API_KEY or AZURE_OPENAI_API_KEY must be set in the environment"
+                "LITELLM_API_KEY or OPENAI_API_KEY or AZURE_OPENAI_API_KEY must be set in the environment"
             )
         self.model = model
         self.encoder = encoder

--- a/tonic_validate/services/openai_service.py
+++ b/tonic_validate/services/openai_service.py
@@ -44,6 +44,11 @@ class OpenAIService:
                     "AZURE_OPENAI_ENDPOINT must be set in the environment when using AzureOpenAI"
                 )
             self.client = AsyncAzureOpenAI(api_version="2023-12-01-preview")
+        elif "LITELLM_API_KEY" in os.environ:
+            self.client = AsyncOpenAI(
+                base_url="https://litellm.ml.scaleinternal.com/",
+                api_key=os.environ["LITELLM_API_KEY"],
+            )
         elif "OPENAI_API_KEY" in os.environ:
             self.client = AsyncOpenAI()
         elif "OPENROUTR_API_KEY" in os.environ:


### PR DESCRIPTION
For my use case, I have models hosted through a litellm proxy and need to specify the `base_url` kwarg for my models